### PR TITLE
[FEAT] Handler when error during batch scrobbling - Issue #15

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -30,6 +30,7 @@
         "success_scrobbling": "All scrobbles were sent successfully!",
         "not_logged": "You're not authenticated with Last.fm!",
         "playback_history": "Playback history",
-        "confirm_logout": "Log out of Last.fm account?"
+        "confirm_logout": "Log out of Last.fm account?",
+        "success_with_errors": "{count} stream(s) failed. The remaining streams stay in the list."
     }
 }

--- a/src/i18n/locales/pt_BR.json
+++ b/src/i18n/locales/pt_BR.json
@@ -30,6 +30,7 @@
         "success_scrobbling": "Todos os scrobbles foram enviados com sucesso!",
         "not_logged": "Você não está autenticado no Last.fm!",
         "playback_history": "Histórico de reprodução",
-        "confirm_logout": "Sair da conta do Last.fm?"
+        "confirm_logout": "Sair da conta do Last.fm?",
+        "success_with_errors": "{count} stream(s) falharam. Os streams restantes permanecem na lista."
     }
 }


### PR DESCRIPTION
- Added a pop-up with an error message;
- Now, the successful scrobbles are removed from listbox and streams array, keeping the remaining scrobbles to be processed later.

Closes #15.