### PR TITLE
[FEAT] Improve update checking - Issue #26

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -125,13 +125,18 @@ def process_streams():
 
     send_scrobbles_button.config(state="normal" if len(streams) > 0 else "disabled")
 
+def parse_version(name: str) -> list[int]:
+    version = name.split(".")
+    version = [int(number) for number in version]
+    return version
+
 def check_for_updates(user_request: bool):
     try:
         current_version = about_dialog.version
         response = requests.get("https://api.github.com/repos/luisgbr1el/last-batch/releases/latest", timeout=10)
-        latest_version = response.json()["name"]
+        latest_version = parse_version(response.json()["name"])
 
-        if current_version != latest_version:
+        if latest_version > current_version:
             confirm = messagebox.askyesno(translator.t("settings.update"), translator.t("messages.update_available"))
 
             if confirm == True:

--- a/src/ui/about_dialog.py
+++ b/src/ui/about_dialog.py
@@ -3,7 +3,8 @@ import webbrowser
 from i18n import translator
 
 defaultBg = "#212120"
-version = "1.2.0"
+version = [1, 2, 0]
+versionText = f"{version[0]}.{version[1]}.{version[2]}"
 
 def open():
     top = ttk.Toplevel(bg=defaultBg)
@@ -13,7 +14,7 @@ def open():
     top.grab_set()
     top.transient()
 
-    label = ttk.Label(top, text=f"{translator.t("settings.version")}: {version}\n{translator.t("messages.developer")}", background=defaultBg, foreground="white", font=("Arial", 10))
+    label = ttk.Label(top, text=f"{translator.t("settings.version")}: {versionText}\n{translator.t("messages.developer")}", background=defaultBg, foreground="white", font=("Arial", 10))
     label.pack(padx=10, pady=10)
 
     button = ttk.Button(top, text="GitHub", command=lambda: webbrowser.open("https://github.com/luisgbr1el/last-batch"), width=25)


### PR DESCRIPTION
- Now the "update available" pop-up appears only if the current app version you're using is below the GitHub's latest release.

Closes #26.